### PR TITLE
updating code example to work for copy/paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ npm install --save sse-channel
 ```js
 var SseChannel = require('sse-channel');
 var http = require('http');
+var require = require('os');
 
 // Set up a new channel. Most of these options have sane defaults,
 // feel free to look at lib/sse-channel.js for all available options


### PR DESCRIPTION
Noticed when trying to just get the example running and ping it you aren't actually able to unless you remove `os.freemem()` or just add the missing declaration.