### PR TITLE
Fix eslint errors

### DIFF
--- a/lib/sse-channel.js
+++ b/lib/sse-channel.js
@@ -261,7 +261,7 @@ function initializeConnection(opts) {
     opts.response.writeHead(200, {
         'Content-Type': 'text/event-stream',
         'Cache-Control': 'no-cache',
-        Connection: 'keep-alive'
+        'Connection': 'keep-alive'
     });
 
     opts.response.write(':ok\n\n');

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
   },
   "devDependencies": {
     "compression": "^1.5.1",
-    "eslint": "^0.24.1",
-    "eslint-config-vaffel": "^1.0.0",
+    "eslint": "^1.10.3",
+    "eslint-config-vaffel": "^3.0.0",
     "eventsource": "^0.1.6",
     "express": "^4.13.1",
     "hapi": "^8.8.0",

--- a/test/sse-channel.test.js
+++ b/test/sse-channel.test.js
@@ -585,8 +585,8 @@ describe('sse-channel', function() {
         var opts = url.parse(host + path);
         opts.method = 'OPTIONS';
         opts.headers = {
-            Accept: 'text/event-stream',
-            Origin: 'http://imbo.io',
+            'Accept': 'text/event-stream',
+            'Origin': 'http://imbo.io',
             'Last-Event-Id': '1337',
             'Access-Control-Request-Method': 'GET'
         };


### PR DESCRIPTION
Linting currently fails with the following error:

```
Error: eslint-config-vaffel:
        Configuration for rule "indent" is invalid:
        Value "data["2"].SwitchCase" has additional properties.
```

Upgrading eslint and eslint-config-vaffel resolves it. This PR also adds some quotes for consistency and resolves `quote-props` errors.