### PR TITLE
Replace deprecated flush() with flushHeaders()

### DIFF
--- a/lib/sse-channel.js
+++ b/lib/sse-channel.js
@@ -231,7 +231,7 @@ SseChannel.prototype.sendEventsSinceId = function(response, sinceId) {
         response.write(msg);
     });
 
-    flush(response);
+    flushHeaders(response);
 };
 
 /**
@@ -278,7 +278,7 @@ function initializeConnection(opts) {
         opts.response.write(':' + preambleData);
     }
 
-    flush(opts.response);
+    flushHeaders(opts.response);
 }
 
 /**
@@ -291,21 +291,21 @@ function broadcast(connections, packet) {
     var i = connections.length;
     while (i--) {
         connections[i].write(packet);
-        flush(connections[i]);
+        flushHeaders(connections[i]);
     }
 }
 
 /**
- * Calls `flush()` on the response if it exists. This is necessary in the case
+ * Calls `flushHeaders()` on the response if it exists. This is necessary in the case
  * when you are using the `compression` middleware for express.js, where the
  * middleware will wait for a certain amount of data before sending it to the
  * client in order to compress in a more efficient manner.
  *
  * @param {Response} response Response object to flush
  */
-function flush(response) {
-    if (response.flush) {
-        response.flush();
+function flushHeaders(response) {
+    if (response.flushHeaders) {
+        response.flushHeaders();
     }
 }
 

--- a/test/sse-channel.test.js
+++ b/test/sse-channel.test.js
@@ -654,14 +654,14 @@ describe('sse-channel', function() {
     });
 
     it('calls flush() after writes if the method exists on response', function(done) {
-        // Initialize a server with a custom `flush()` method added on each incoming request,
-        // mimicking the `compression` middleware. Check that we call `flush()`:
+        // Initialize a server with a custom `flushHeaders()` method added on each incoming request,
+        // mimicking the `compression` middleware. Check that we call `flushHeaders()`:
         //   - On connect, after the initial headers, retry, and preamble has been written
         //   - After "missed events" have been sent (once)
         //   - After each broadcast
         var flushes = 0;
         initServer({
-            flush: function() {
+            flushHeaders: function() {
                 flushes++;
             },
             history: [

--- a/test/util/server-init.js
+++ b/test/util/server-init.js
@@ -7,8 +7,8 @@ module.exports = function(opts) {
     var channel = new Channel(opts);
 
     var server = http.createServer(function(req, res) {
-        if (opts.flush) {
-            res.flush = opts.flush;
+        if (opts.flushHeaders) {
+            res.flushHeaders = opts.flushHeaders;
         }
 
         channel.addClient(req, res, opts.addClientCallback);


### PR DESCRIPTION
Node was complaining about the use of the now-deprecated `flush()` function:
```
OutgoingMessage.flush is deprecated. Use flushHeaders instead.
```
Replacing `flush()` with `flushHeaders()` removes the warning.