### PR TITLE
Fix connectionCount

### DIFF
--- a/lib/sse-channel.js
+++ b/lib/sse-channel.js
@@ -108,7 +108,9 @@ SseChannel.prototype.addClient = function(req, res, callback) {
 
     // Add the connection to our pool
     this.connections.push(res);
-    this.connectionCount++;
+    //It would be preferable to not expose this.connectionCount at all and force users to use getConnectionCount
+    //However, this PR should be backwards compatible. Maybe add a deprecation message?
+    this.connectionCount = this.connections.length;
 
     // When the client disconnects, remove the client
     var removeClient = this.removeClient.bind(this, res);
@@ -144,7 +146,7 @@ SseChannel.prototype.addClient = function(req, res, callback) {
  */
 SseChannel.prototype.removeClient = function(res) {
     pull(this.connections, res);
-    this.connectionCount--;
+    this.connectionCount = this.connections.length;
 
     this.emit('disconnect', this, res);
 };
@@ -155,7 +157,7 @@ SseChannel.prototype.removeClient = function(res) {
  * @return {Number} Number of active connections
  */
 SseChannel.prototype.getConnectionCount = function() {
-    return this.connectionCount;
+    return this.connections.length;
 };
 
 /**


### PR DESCRIPTION
connectionCount is unreliable. If you call res.close() the disconnect event can be fired multiple times. Because connectionCount was being decremented in the disconnect handler (called multiple times), you end up with a situation where the number of connections doesn't match the connectionCount.